### PR TITLE
Fix infinite loop in GetTable

### DIFF
--- a/pkg/rekordbox/dbengine/table.go
+++ b/pkg/rekordbox/dbengine/table.go
@@ -39,6 +39,9 @@ func (db *DbEngine) GetTable(pageType page.Type) (*Table, error) {
 	nextPage := idx.IndexHeader.NextPage
 
 	for {
+		if nextPage == emptyTable {
+			break
+		}
 		var data *page.Data
 		err = db.seekToPage(nextPage)
 		if err != nil {


### PR DESCRIPTION
Fix infinite loop in GetTable by checking for emptyTable before processing pages

This fixes issue #6 where a `fatal error: seek...` message was appearing and parsing stopped prematurely. I added a print statement to see the value of `nextpage` in each iteration and saw the following:
```bash
nextPage=67108863
fatal error: seek /run/media/llucsm/FA1C-FC51/PIONEER/rekordbox/EXPORT.PDB: invalid argument
```
This 67108863 is the value of emptyTable according to `pkg/rekordbox/dbengine/db.go`:
```go
const emptyTable untyped int = 0x03ffffff // 67108863
```
Thus, checking for emptyTable before processing does allow the program to finish parsing the export.pdb files